### PR TITLE
Popravek definicije funkcije obrni'

### DIFF
--- a/07-ucinki-in-cistost/predavanja/dokazovanje.mdown
+++ b/07-ucinki-in-cistost/predavanja/dokazovanje.mdown
@@ -284,7 +284,7 @@ Bolje je, če uporabimo funkcijo `obrni'`, ki uporablja akumulator in je definir
 ```ocaml
 let obrni' =
   let rec aux acc = function
-    | [] -> aux
+    | [] -> acc
     | x :: xs -> aux (x :: acc) xs
   in
   aux []


### PR DESCRIPTION
Vrstica 287 v definiciji funkcije `obrni'` zamenjal | [] -> aux v | [] -> acc.